### PR TITLE
add package build script

### DIFF
--- a/edge/.gitignore
+++ b/edge/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 RTIMULib.ini
 .env
+app.zip

--- a/edge/README.md
+++ b/edge/README.md
@@ -13,4 +13,11 @@ deviceId='<Device ID>' mqttServer='<MQTT broker server>' node app.js
 # If you want to automatically restart the app
 npm install -g pm2
 pm2 start app.js
+
+```
+
+## How to build a zip package
+```
+npm run-script build
+sudo cp app.zip /boot/
 ```

--- a/edge/package.json
+++ b/edge/package.json
@@ -5,7 +5,7 @@
     "main": "app.js",
     "scripts": {
         "start": "node app.js",
-        "test": "echo \"Error: no test specified\" && exit 1"
+        "build": "zip -9r app.zip package.json app.js node_modules"
     },
     "author": "",
     "license": "ISC",


### PR DESCRIPTION
To use with "startup.sh" script, you need to pack code and modules in a zip file and place it as /boot/app.zip.
You can make a zip file with `npm run-script build` command.

You may need to install zip command with `apt-get install zip`.